### PR TITLE
Fix nil panic when info.Dirs is missing

### DIFF
--- a/gen/traverse.go
+++ b/gen/traverse.go
@@ -21,10 +21,12 @@ func (r *Renderer) GenerateAll(pkgPath, targetDir string) error {
 	}
 
 	info := r.pres.GetPkgPageInfo(path.Join("/src", r.ModPath), r.ModPath, r.pres.GetPageInfoMode(rootReq))
-	for _, dir := range info.Dirs.List {
-		err := r.Generate(dir.Path)
-		if err != nil {
-			return err
+	if info.Dirs != nil {
+		for _, dir := range info.Dirs.List {
+			err := r.Generate(dir.Path)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Thanks for this tool! Very easy to use and does exactly what I needed.

I ran into a panic in my first run, and turns out this `Dirs` field can be nil sometimes. I'm not sure if this needs further testing, but this patch generated the necessary package index for me 👍 